### PR TITLE
incompatible with mplayer2

### DIFF
--- a/mplayer-resumer
+++ b/mplayer-resumer
@@ -119,7 +119,7 @@ sub mplayer () {
     my($parameters,$infile)=@_;
     my $seconds=0;
     my $timecode=&get_time_offset($infile);
-    my $command = "mplayer $parameters -ss $timecode \"$infile\" 2>&1 2>/dev/null |";
+    my $command = "mplayer $parameters -ss $timecode \"$infile\" 2>&1 |";
 
     open(SHELL, $command);
     # The kind of line we care about looks like this example:


### PR DESCRIPTION
For some reason, mplayer2 outputs the most important line (the one with the current position) to stderr (2). Trying to fix that.
